### PR TITLE
Fix crash on import due to bad color names

### DIFF
--- a/pygcurse/__init__.py
+++ b/pygcurse/__init__.py
@@ -74,9 +74,11 @@ SOUTHEAST = 'SE'
 SOUTHWEST = 'SW'
 
 # A mapping of strings to color objects.
+#This is directly derived from the strings Pygame offers as representing
+#colors via its .colordict module so it's 99.9% guaranteed to be correct
 colornames = {}
-for cname in 'white yellow fuchsia red silver gray olive purple maroon aqua lime teal green blue navy black'.split(' '):
-    colornames[cname] = pygame.Color(cname)
+for cname, colortuple in pygame.colordict.THECOLORS.items():
+    colornames[cname] = pygame.Color(*colortuple)
 
 
 class PygcurseSurface(object):


### PR DESCRIPTION
The list of strings used to gather color names was inaccurate and caused Pygame to raise ValueError when those strings were passed to pygame.Color() upon importing `pygcurse`. I've fixed it so that we now read directly from (what I assume is) the database from which Pygame reads its color name-tuple pairs instead of just having a bunch of hard-coded names lying around.